### PR TITLE
Added flexible space matching for Section markers

### DIFF
--- a/syntaxes/psl.tmLanguage.json
+++ b/syntaxes/psl.tmLanguage.json
@@ -278,7 +278,7 @@
 				{
 					"name": "comment.block.psl",
 					"begin": "^---------- REVHIST ------ Section marker",
-					"end": "^---------- OPEN ------ Section marker",
+					"end": "^---------- OPEN\\s+------ Section marker",
 					"beginCaptures": {
 						"0": {
 							"patterns": [


### PR DESCRIPTION
Our older batch definitions have 4 spaces after the OPEN section marker, which fails the current pattern, and so the whole file ends up formatted like a comment. This change fixes that problem.