### PR TITLE
Generalize lint framework

### DIFF
--- a/__tests__/ruleUtils.ts
+++ b/__tests__/ruleUtils.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { parseText } from '../src/parser/parser';
 import * as activate from '../src/pslLint/activate';
 import * as api from '../src/pslLint/api';
 
@@ -24,8 +25,8 @@ export async function getDiagnostics(testFileName: string, ruleName?: string): P
 	const testFilePath = path.resolve('__tests__', 'files', testFileName);
 	const text = await fs.readFile(testFilePath).then(b => b.toString());
 
-	const profileComponent = new api.ProfileComponent(testFilePath, text, api.parseText(text));
-	const diagnostics = activate.getDiagnostics(profileComponent, false);
+	const profileComponent = new api.ProfileComponent(testFilePath, text);
+	const diagnostics = activate.getDiagnostics(profileComponent, parseText(text), false);
 	if (ruleName) return diagnostics.filter(d => d.ruleName === ruleName);
 	return diagnostics;
 }

--- a/__tests__/ruleUtils.ts
+++ b/__tests__/ruleUtils.ts
@@ -24,8 +24,8 @@ export async function getDiagnostics(testFileName: string, ruleName?: string): P
 	const testFilePath = path.resolve('__tests__', 'files', testFileName);
 	const text = await fs.readFile(testFilePath).then(b => b.toString());
 
-	const pslDocument = new api.ProfileComponent(api.parseText(text), text, testFilePath);
-	const diagnostics = activate.getDiagnostics(pslDocument, false);
+	const profileComponent = new api.ProfileComponent(testFilePath, text, api.parseText(text));
+	const diagnostics = activate.getDiagnostics(profileComponent, false);
 	if (ruleName) return diagnostics.filter(d => d.ruleName === ruleName);
 	return diagnostics;
 }

--- a/__tests__/ruleUtils.ts
+++ b/__tests__/ruleUtils.ts
@@ -24,7 +24,7 @@ export async function getDiagnostics(testFileName: string, ruleName?: string): P
 	const testFilePath = path.resolve('__tests__', 'files', testFileName);
 	const text = await fs.readFile(testFilePath).then(b => b.toString());
 
-	const pslDocument = new api.PslDocument(api.parseText(text), text, testFilePath);
+	const pslDocument = new api.ProfileComponent(api.parseText(text), text, testFilePath);
 	const diagnostics = activate.getDiagnostics(pslDocument, false);
 	if (ruleName) return diagnostics.filter(d => d.ruleName === ruleName);
 	return diagnostics;

--- a/src/language/codeQuality.ts
+++ b/src/language/codeQuality.ts
@@ -103,7 +103,7 @@ function lint(
 	lintDiagnostics: vscode.DiagnosticCollection,
 ) {
 	const documentText = textDocument.getText();
-	const pslDocument: api.PslDocument = prepareDocument(documentText, textDocument);
+	const pslDocument: api.ProfileComponent = prepareDocument(documentText, textDocument);
 	const diagnostics = getDiagnostics(pslDocument, useConfig);
 	const memberDiagnostics = transform(diagnostics, textDocument.uri);
 	process.nextTick(() => {
@@ -116,7 +116,7 @@ function lint(
 function prepareDocument(documentText: string, textDocument: vscode.TextDocument) {
 	const parsedDocument = parser.parseText(documentText);
 	const getTextAtLine = (n: number) => textDocument.lineAt(n).text;
-	const pslDocument = new api.PslDocument(parsedDocument, documentText, textDocument.uri.fsPath, getTextAtLine);
+	const pslDocument = new api.ProfileComponent(parsedDocument, documentText, textDocument.uri.fsPath, getTextAtLine);
 	return pslDocument;
 }
 

--- a/src/language/codeQuality.ts
+++ b/src/language/codeQuality.ts
@@ -103,8 +103,8 @@ function lint(
 	lintDiagnostics: vscode.DiagnosticCollection,
 ) {
 	const documentText = textDocument.getText();
-	const pslDocument: api.ProfileComponent = prepareDocument(documentText, textDocument);
-	const diagnostics = getDiagnostics(pslDocument, useConfig);
+	const profileComponent: api.ProfileComponent = prepareDocument(documentText, textDocument);
+	const diagnostics = getDiagnostics(profileComponent, useConfig);
 	const memberDiagnostics = transform(diagnostics, textDocument.uri);
 	process.nextTick(() => {
 		if (!cancellationToken.isCancellationRequested) {
@@ -116,8 +116,13 @@ function lint(
 function prepareDocument(documentText: string, textDocument: vscode.TextDocument) {
 	const parsedDocument = parser.parseText(documentText);
 	const getTextAtLine = (n: number) => textDocument.lineAt(n).text;
-	const pslDocument = new api.ProfileComponent(parsedDocument, documentText, textDocument.uri.fsPath, getTextAtLine);
-	return pslDocument;
+	const profileComponent = new api.ProfileComponent(
+		textDocument.uri.fsPath,
+		documentText,
+		parsedDocument,
+		getTextAtLine,
+	);
+	return profileComponent;
 }
 
 function transform(diagnostics: api.Diagnostic[], uri: vscode.Uri): MemberDiagnostic[] {

--- a/src/language/codeQuality.ts
+++ b/src/language/codeQuality.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { BATCH_MODE, PSL_MODE, TRIG_MODE } from '../extension';
+import { PSL_MODE } from '../extension';
 import * as parser from '../parser/parser';
 import { getDiagnostics } from '../pslLint/activate';
 import * as api from '../pslLint/api';
@@ -35,7 +35,6 @@ export async function activate(context: vscode.ExtensionContext) {
 	});
 
 	vscode.workspace.onDidCloseTextDocument(closedDocument => {
-		if (!isProfileElement(closedDocument)) return;
 		lintDiagnostics.delete(closedDocument.uri);
 	});
 
@@ -77,7 +76,7 @@ function prepareRules(
 	lintDiagnostics: vscode.DiagnosticCollection,
 	cancellationToken: vscode.CancellationToken,
 ) {
-	if (!isProfileElement(textDocument)) return;
+	if (!api.ProfileComponent.isProfileComponent(textDocument.fileName)) return;
 
 	const lintConfigValue: lintOption = vscode.workspace.getConfiguration('psl', textDocument.uri).get('lint');
 
@@ -102,9 +101,10 @@ function lint(
 	useConfig: boolean, cancellationToken: vscode.CancellationToken,
 	lintDiagnostics: vscode.DiagnosticCollection,
 ) {
-	const documentText = textDocument.getText();
-	const profileComponent: api.ProfileComponent = prepareDocument(documentText, textDocument);
-	const diagnostics = getDiagnostics(profileComponent, useConfig);
+	const profileComponent: api.ProfileComponent = prepareDocument(textDocument);
+	const parsedDocument = api.ProfileComponent.isPsl(profileComponent.fsPath) ?
+		parser.parseText(textDocument.getText()) : undefined;
+	const diagnostics = getDiagnostics(profileComponent, parsedDocument, useConfig);
 	const memberDiagnostics = transform(diagnostics, textDocument.uri);
 	process.nextTick(() => {
 		if (!cancellationToken.isCancellationRequested) {
@@ -113,15 +113,9 @@ function lint(
 	});
 }
 
-function prepareDocument(documentText: string, textDocument: vscode.TextDocument) {
-	const parsedDocument = parser.parseText(documentText);
+function prepareDocument(textDocument: vscode.TextDocument) {
 	const getTextAtLine = (n: number) => textDocument.lineAt(n).text;
-	const profileComponent = new api.ProfileComponent(
-		textDocument.uri.fsPath,
-		documentText,
-		parsedDocument,
-		getTextAtLine,
-	);
+	const profileComponent = new api.ProfileComponent(textDocument.uri.fsPath, textDocument.getText(), getTextAtLine);
 	return profileComponent;
 }
 
@@ -149,10 +143,4 @@ function transform(diagnostics: api.Diagnostic[], uri: vscode.Uri): MemberDiagno
 		}
 		return memberDiagnostic;
 	});
-}
-
-function isProfileElement(textDocument: vscode.TextDocument) {
-	return vscode.languages.match(PSL_MODE, textDocument) ||
-		vscode.languages.match(BATCH_MODE, textDocument) ||
-		vscode.languages.match(TRIG_MODE, textDocument);
 }

--- a/src/parser/utilities.ts
+++ b/src/parser/utilities.ts
@@ -400,3 +400,9 @@ export function findCallable(tokensOnLine: Token[], index: number) {
 export function getLineAfter(method: Method): number {
 	return method.closeParen ? method.closeParen.position.line + 1 : method.id.position.line + 1;
 }
+
+export function getCommentsOnLine(parsedDocument: ParsedDocument, lineNumber: number): Token[] {
+	return parsedDocument.comments.filter(t => {
+		return t.position.line === lineNumber;
+	});
+}

--- a/src/pslLint/activate.ts
+++ b/src/pslLint/activate.ts
@@ -1,14 +1,17 @@
 import * as path from 'path';
 import {
-	DeclarationRule, Diagnostic, ProfileComponentRule, MemberRule, MethodRule, ParameterRule, PropertyRule, ProfileComponent,
+	DeclarationRule, Diagnostic, MemberRule, MethodRule,
+	ParameterRule, ProfileComponent, ProfileComponentRule, PropertyRule,
 } from './api';
 import { getConfig, matchConfig } from './config';
 
 /**
  * Import rules here.
  */
-import { MemberCamelCase, MemberLength, MemberLiteralCase,
-		MemberStartsWithV, PropertyIsDummy} from './elementsConventionChecker';
+import {
+	MemberCamelCase, MemberLength, MemberLiteralCase,
+	MemberStartsWithV, PropertyIsDummy,
+} from './elementsConventionChecker';
 import { MethodDocumentation, MethodSeparator, TwoEmptyLines } from './methodDoc';
 import { MultiLineDeclare } from './multiLineDeclare';
 import { MethodParametersOnNewLine } from './parameters';
@@ -41,8 +44,8 @@ const propertyRules: PropertyRule[] = [
 const declarationRules: DeclarationRule[] = [];
 const parameterRules: ParameterRule[] = [];
 
-export function getDiagnostics(pslDocument: ProfileComponent, useConfig?: boolean): Diagnostic[] {
-	const subscription = new RuleSubscription(pslDocument, useConfig);
+export function getDiagnostics(profileComponent: ProfileComponent, useConfig?: boolean): Diagnostic[] {
+	const subscription = new RuleSubscription(profileComponent, useConfig);
 	return subscription.reportRules();
 }
 
@@ -59,15 +62,15 @@ class RuleSubscription {
 	private filteredDeclarationRules: DeclarationRule[];
 	private filteredParameterRules: ParameterRule[];
 
-	constructor(private pslDocument: ProfileComponent, useConfig?: boolean) {
+	constructor(private profileComponent: ProfileComponent, useConfig?: boolean) {
 		this.diagnostics = [];
 
-		const config = useConfig ? getConfig(this.pslDocument.fsPath) : undefined;
+		const config = useConfig ? getConfig(this.profileComponent.fsPath) : undefined;
 
 		const filterRules = (rules: ProfileComponentRule[]) => {
 			return rules.filter(rule => {
 				if (!config) return true;
-				return matchConfig(path.basename(this.pslDocument.fsPath), rule.ruleName, config);
+				return matchConfig(path.basename(this.profileComponent.fsPath), rule.ruleName, config);
 			});
 		};
 
@@ -81,22 +84,22 @@ class RuleSubscription {
 
 	reportRules(): Diagnostic[] {
 		const addDiagnostics = (rules: ProfileComponentRule[], ...args: any[]) => {
-			rules.forEach(rule => this.diagnostics.push(...rule.report(this.pslDocument, ...args)));
+			rules.forEach(rule => this.diagnostics.push(...rule.report(this.profileComponent, ...args)));
 		};
 
 		addDiagnostics(this.filteredDocumentRules);
 
-		for (const property of this.pslDocument.parsedDocument.properties) {
+		for (const property of this.profileComponent.parsedDocument.properties) {
 			addDiagnostics(this.filteredMemberRules, property);
 			addDiagnostics(this.filteredPropertyRules, property);
 		}
 
-		for (const declaration of this.pslDocument.parsedDocument.declarations) {
+		for (const declaration of this.profileComponent.parsedDocument.declarations) {
 			addDiagnostics(this.filteredMemberRules, declaration);
 			addDiagnostics(this.filteredDeclarationRules, declaration);
 		}
 
-		for (const method of this.pslDocument.parsedDocument.methods) {
+		for (const method of this.profileComponent.parsedDocument.methods) {
 			addDiagnostics(this.filteredMemberRules, method);
 			addDiagnostics(this.filteredMethodRules, method);
 

--- a/src/pslLint/activate.ts
+++ b/src/pslLint/activate.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import {
-	DeclarationRule, Diagnostic, DocumentRule, MemberRule, MethodRule, ParameterRule, PropertyRule, PslDocument,
+	DeclarationRule, Diagnostic, ProfileComponentRule, MemberRule, MethodRule, ParameterRule, PropertyRule, ProfileComponent,
 } from './api';
 import { getConfig, matchConfig } from './config';
 
@@ -18,7 +18,7 @@ import { TodoInfo } from './todos';
 /**
  * Add new rules here to have them checked at the appropriate time.
  */
-const documentRules: DocumentRule[] = [
+const documentRules: ProfileComponentRule[] = [
 	new TodoInfo(),
 ];
 const memberRules: MemberRule[] = [
@@ -41,7 +41,7 @@ const propertyRules: PropertyRule[] = [
 const declarationRules: DeclarationRule[] = [];
 const parameterRules: ParameterRule[] = [];
 
-export function getDiagnostics(pslDocument: PslDocument, useConfig?: boolean): Diagnostic[] {
+export function getDiagnostics(pslDocument: ProfileComponent, useConfig?: boolean): Diagnostic[] {
 	const subscription = new RuleSubscription(pslDocument, useConfig);
 	return subscription.reportRules();
 }
@@ -52,19 +52,19 @@ export function getDiagnostics(pslDocument: PslDocument, useConfig?: boolean): D
 class RuleSubscription {
 
 	private diagnostics: Diagnostic[];
-	private filteredDocumentRules: DocumentRule[];
+	private filteredDocumentRules: ProfileComponentRule[];
 	private filteredMethodRules: MethodRule[];
 	private filteredMemberRules: MemberRule[];
 	private filteredPropertyRules: PropertyRule[];
 	private filteredDeclarationRules: DeclarationRule[];
 	private filteredParameterRules: ParameterRule[];
 
-	constructor(private pslDocument: PslDocument, useConfig?: boolean) {
+	constructor(private pslDocument: ProfileComponent, useConfig?: boolean) {
 		this.diagnostics = [];
 
 		const config = useConfig ? getConfig(this.pslDocument.fsPath) : undefined;
 
-		const filterRules = (rules: DocumentRule[]) => {
+		const filterRules = (rules: ProfileComponentRule[]) => {
 			return rules.filter(rule => {
 				if (!config) return true;
 				return matchConfig(path.basename(this.pslDocument.fsPath), rule.ruleName, config);
@@ -80,7 +80,7 @@ class RuleSubscription {
 	}
 
 	reportRules(): Diagnostic[] {
-		const addDiagnostics = (rules: DocumentRule[], ...args: any[]) => {
+		const addDiagnostics = (rules: ProfileComponentRule[], ...args: any[]) => {
 			rules.forEach(rule => this.diagnostics.push(...rule.report(this.pslDocument, ...args)));
 		};
 

--- a/src/pslLint/api.ts
+++ b/src/pslLint/api.ts
@@ -113,44 +113,39 @@ export class DiagnosticRelatedInformation {
 	}
 }
 
-/**
- * An interface for writing new rules
- */
-export interface DocumentRule {
+export interface ProfileComponentRule {
 
 	ruleName: string;
 
 	/**
-	 *
-	 * @param pslDocument An abstract representation of a PSL document
-	 * @param textDocument The whole text of the document, as a string.
+	 * @param profileComponent An abstract representation of a PSL document
 	 */
-	report(pslDocument: PslDocument, ...args: any[]): Diagnostic[];
+	report(profileComponent: ProfileComponent, ...args: any[]): Diagnostic[];
 }
 
-export interface MemberRule extends DocumentRule {
-	report(pslDocument: PslDocument, member: Member): Diagnostic[];
+export interface MemberRule extends ProfileComponentRule {
+	report(profileComponent: ProfileComponent, member: Member): Diagnostic[];
 }
 
-export interface PropertyRule extends DocumentRule {
-	report(pslDocument: PslDocument, property: Property): Diagnostic[];
+export interface PropertyRule extends ProfileComponentRule {
+	report(profileComponent: ProfileComponent, property: Property): Diagnostic[];
 }
 
-export interface MethodRule extends DocumentRule {
-	report(pslDocument: PslDocument, method: Method): Diagnostic[];
+export interface MethodRule extends ProfileComponentRule {
+	report(profileComponent: ProfileComponent, method: Method): Diagnostic[];
 }
 
-export interface ParameterRule extends DocumentRule {
-	report(pslDocument: PslDocument, parameter: Parameter, method: Method): Diagnostic[];
+export interface ParameterRule extends ProfileComponentRule {
+	report(profileComponent: ProfileComponent, parameter: Parameter, method: Method): Diagnostic[];
 }
 
-export interface DeclarationRule extends DocumentRule {
-	report(pslDocument: PslDocument, declaration: Declaration, method?: Method): Diagnostic[];
+export interface DeclarationRule extends ProfileComponentRule {
+	report(profileComponent: ProfileComponent, declaration: Declaration, method?: Method): Diagnostic[];
 }
 
 type GetTextMethod = (lineNumber: number) => string;
 
-export class PslDocument {
+export class ProfileComponent {
 
 	parsedDocument: ParsedDocument;
 	textDocument: string;

--- a/src/pslLint/api.ts
+++ b/src/pslLint/api.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { Declaration, Member, Method, Parameter, ParsedDocument, Property } from './../parser/parser';
-import { Range, Token } from './../parser/tokenizer';
+import { Range } from './../parser/tokenizer';
 
 export enum DiagnosticSeverity {
 
@@ -113,9 +113,7 @@ export class DiagnosticRelatedInformation {
 
 export abstract class ProfileComponentRule {
 
-	readonly ruleName: string = (() => {
-		return this.constructor.name;
-	})();
+	readonly ruleName: string = this.constructor.name;
 
 	private _profileComponent: ProfileComponent;
 
@@ -129,6 +127,8 @@ export abstract class ProfileComponentRule {
 		this._profileComponent = v;
 	}
 }
+
+export abstract class FileDefinitionRule extends ProfileComponentRule { }
 
 export abstract class PslRule extends ProfileComponentRule {
 
@@ -170,22 +170,24 @@ type GetTextMethod = (lineNumber: number) => string;
 /**
  * A ProfileComponent contains information about a file used in Profile.
  * The file may be PSL or non-PSL (such as a TBL or COL).
- *
- * The path on the filesystem is available, as well as the components's text contents.
- * In the case where the component is PSL, the parsedDocument property is defined.
  */
 export class ProfileComponent {
 
 	static isPsl(fsPath: string): boolean {
-		return path.extname(fsPath) !== '.PROC'
-			|| path.extname(fsPath) !== '.BATCH'
-			|| path.extname(fsPath).toUpperCase() !== '.PSL';
+		return path.extname(fsPath) === '.PROC'
+			|| path.extname(fsPath) === '.BATCH'
+			|| path.extname(fsPath) === '.TRIG'
+			|| path.extname(fsPath).toUpperCase() === '.PSL';
+	}
+
+	static isFileDefinition(fsPath: string): boolean {
+		return path.extname(fsPath) === '.TBL'
+			|| path.extname(fsPath) === '.COL';
 	}
 
 	static isProfileComponent(fsPath: string): boolean {
 		return ProfileComponent.isPsl(fsPath)
-			|| path.extname(fsPath) !== '.TBL'
-			|| path.extname(fsPath) !== '.COL';
+			|| ProfileComponent.isFileDefinition(fsPath);
 	}
 
 	fsPath: string;
@@ -227,10 +229,4 @@ export class ProfileComponent {
 		}
 		return indexedDocument;
 	}
-}
-
-export function getCommentsOnLine(parsedDocument: ParsedDocument, lineNumber: number): Token[] {
-	return parsedDocument.comments.filter(t => {
-		return t.position.line === lineNumber;
-	});
 }

--- a/src/pslLint/api.ts
+++ b/src/pslLint/api.ts
@@ -115,34 +115,18 @@ export abstract class ProfileComponentRule {
 
 	readonly ruleName: string = this.constructor.name;
 
-	private _profileComponent: ProfileComponent;
+	profileComponent: ProfileComponent;
 
 	abstract report(...args: any[]): Diagnostic[];
-
-	get profileComponent(): ProfileComponent {
-		return this._profileComponent;
-	}
-
-	set profileComponent(v: ProfileComponent) {
-		this._profileComponent = v;
-	}
 }
 
 export abstract class FileDefinitionRule extends ProfileComponentRule { }
 
 export abstract class PslRule extends ProfileComponentRule {
 
-	private _parsedDocument: ParsedDocument;
+	parsedDocument: ParsedDocument;
 
 	abstract report(...args: any[]): Diagnostic[];
-
-	get parsedDocument(): ParsedDocument {
-		return this._parsedDocument;
-	}
-
-	set parsedDocument(v: ParsedDocument) {
-		this._parsedDocument = v;
-	}
 }
 
 export abstract class MemberRule extends PslRule {

--- a/src/pslLint/cli/cli.ts
+++ b/src/pslLint/cli/cli.ts
@@ -44,12 +44,12 @@ function getMessage(storedDiagnostic: StoredDiagnostic) {
 
 async function readFile(filename: string): Promise<number> {
 	let errorCount = 0;
-	if (!ProfileComponent.isProfileComponent(filename)) {
+	const fsPath = path.relative(process.cwd(), filename);
+	if (!ProfileComponent.isProfileComponent(fsPath)) {
 		return errorCount;
 	}
-	const fsPath = path.relative(process.cwd(), filename);
 	const textDocument = (await fs.readFile(fsPath)).toString();
-	const parsedDocument = parseText(textDocument);
+	const parsedDocument = ProfileComponent.isPsl(fsPath) ? parseText(textDocument) : undefined;
 	const profileComponent = new ProfileComponent(fsPath, textDocument);
 
 	const diagnostics = getDiagnostics(profileComponent, parsedDocument, useConfig);

--- a/src/pslLint/cli/cli.ts
+++ b/src/pslLint/cli/cli.ts
@@ -69,9 +69,9 @@ async function readFile(filename: string): Promise<number> {
 	return errorCount;
 }
 
-function prepareDocument(textDocument: string, filename: string): api.PslDocument {
+function prepareDocument(textDocument: string, filename: string): api.ProfileComponent {
 	const parsedDocument = api.parseText(textDocument);
-	return new api.PslDocument(parsedDocument, textDocument, filename);
+	return new api.ProfileComponent(parsedDocument, textDocument, filename);
 }
 
 export async function readPath(fileString: string) {

--- a/src/pslLint/config.ts
+++ b/src/pslLint/config.ts
@@ -69,7 +69,7 @@ export function matchConfig(fileName: string, ruleName: string, configObj: Regex
 		}
 	};
 
-	matches = findMatch(configObj.include);
+	matches = findMatch(configObj.include) || false;
 	if (!matches) return false;
 	return !findMatch(configObj.exclude);
 }

--- a/src/pslLint/config.ts
+++ b/src/pslLint/config.ts
@@ -32,16 +32,16 @@ export function transform(config: Config): RegexConfig {
 	for (const pattern in config.include) {
 		if (config.include.hasOwnProperty(pattern)) {
 			const rules = config.include[pattern];
-			includes.push({pattern: minimatch.makeRe(pattern), rules});
+			includes.push({ pattern: minimatch.makeRe(pattern), rules });
 		}
 	}
 	for (const pattern in config.exclude) {
 		if (config.exclude.hasOwnProperty(pattern)) {
 			const rules = config.exclude[pattern];
-			excludes.push({pattern: minimatch.makeRe(pattern), rules});
+			excludes.push({ pattern: minimatch.makeRe(pattern), rules });
 		}
 	}
-	return {include: includes, exclude: excludes};
+	return { include: includes, exclude: excludes };
 }
 
 export async function removeConfig(configPath: string) {
@@ -49,9 +49,9 @@ export async function removeConfig(configPath: string) {
 	activeConfigs.delete(configBaseDir);
 }
 
-export function getConfig(fileName: string): RegexConfig | undefined {
+export function getConfig(fsPath: string): RegexConfig | undefined {
 	for (const configBaseDir of activeConfigs.keys()) {
-		const relative = path.relative(configBaseDir, fileName);
+		const relative = path.relative(configBaseDir, fsPath);
 		if (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative)) {
 			return activeConfigs.get(configBaseDir);
 		}

--- a/src/pslLint/elementsConventionChecker.ts
+++ b/src/pslLint/elementsConventionChecker.ts
@@ -7,7 +7,7 @@ export class MethodStartsWithZ implements MethodRule {
 
 	ruleName = MethodStartsWithZ.name;
 
-	report(_parsedDocument: ProfileComponent, method: Method): Diagnostic[] {
+	report(_, method: Method): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
 
 		startsWithZ(method, diagnostics, this.ruleName);
@@ -19,7 +19,7 @@ export class PropertyStartsWithZ implements PropertyRule {
 
 	ruleName = PropertyStartsWithZ.name;
 
-	report(_parsedDocument: ProfileComponent, property: Property): Diagnostic[] {
+	report(_, property: Property): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
 
 		startsWithZ(property, diagnostics, this.ruleName);
@@ -32,9 +32,9 @@ export class PropertyIsDummy implements PropertyRule {
 
 	ruleName = PropertyIsDummy.name;
 
-	report(parsedDocument: ProfileComponent, property: Property): Diagnostic[] {
+	report(profileComponent: ProfileComponent, property: Property): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
-		if (!parsedDocument.parsedDocument.extending) {
+		if (!profileComponent.parsedDocument.extending) {
 			this.isCalledDummy(property, diagnostics);
 		}
 		return diagnostics;
@@ -53,7 +53,7 @@ export class MemberLiteralCase implements MemberRule {
 
 	ruleName = MemberLiteralCase.name;
 
-	report(_parsedDocument: ProfileComponent, member: Member): Diagnostic[] {
+	report(_, member: Member): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
 		this.checkUpperCase(member, diagnostics);
 		return diagnostics;
@@ -73,7 +73,7 @@ export class MemberCamelCase implements MemberRule {
 
 	ruleName = MemberCamelCase.name;
 
-	report(_parsedDocument: ProfileComponent, member: Member): Diagnostic[] {
+	report(_, member: Member): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
 
 		this.memberCase(member, diagnostics);
@@ -132,7 +132,7 @@ export class MemberLength implements MemberRule {
 
 	ruleName = MemberLength.name;
 
-	report(_parsedDocument: ProfileComponent, member: Member): Diagnostic[] {
+	report(_, member: Member): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
 
 		this.checkMemberLength(member, diagnostics);
@@ -155,7 +155,7 @@ export class MemberStartsWithV implements MemberRule {
 
 	ruleName = MemberStartsWithV.name;
 
-	report(_parsedDocument: ProfileComponent, member: Member): Diagnostic[] {
+	report(_, member: Member): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
 
 		this.checkStartsWithV(member, diagnostics);

--- a/src/pslLint/elementsConventionChecker.ts
+++ b/src/pslLint/elementsConventionChecker.ts
@@ -1,13 +1,13 @@
 import {
 	Diagnostic, DiagnosticSeverity, Member, MemberClass, MemberRule,
-	Method, MethodRule, Property, PropertyRule, PslDocument,
+	Method, MethodRule, ProfileComponent, Property, PropertyRule,
 } from './api';
 
 export class MethodStartsWithZ implements MethodRule {
 
 	ruleName = MethodStartsWithZ.name;
 
-	report(_parsedDocument: PslDocument, method: Method): Diagnostic[] {
+	report(_parsedDocument: ProfileComponent, method: Method): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
 
 		startsWithZ(method, diagnostics, this.ruleName);
@@ -19,7 +19,7 @@ export class PropertyStartsWithZ implements PropertyRule {
 
 	ruleName = PropertyStartsWithZ.name;
 
-	report(_parsedDocument: PslDocument, property: Property): Diagnostic[] {
+	report(_parsedDocument: ProfileComponent, property: Property): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
 
 		startsWithZ(property, diagnostics, this.ruleName);
@@ -32,7 +32,7 @@ export class PropertyIsDummy implements PropertyRule {
 
 	ruleName = PropertyIsDummy.name;
 
-	report(parsedDocument: PslDocument, property: Property): Diagnostic[] {
+	report(parsedDocument: ProfileComponent, property: Property): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
 		if (!parsedDocument.parsedDocument.extending) {
 			this.isCalledDummy(property, diagnostics);
@@ -43,7 +43,7 @@ export class PropertyIsDummy implements PropertyRule {
 	isCalledDummy(member: Member, diagnostics: Diagnostic[]): void {
 		if (member.id.value.toLowerCase() === 'dummy') {
 			diagnostics.push(
-				createDiagnostic(member, 'Usage of "dummy" property is discouraged', DiagnosticSeverity.Information, this.ruleName)
+				createDiagnostic(member, 'Usage of "dummy" property is discouraged', DiagnosticSeverity.Information, this.ruleName),
 			);
 		}
 	}
@@ -53,7 +53,7 @@ export class MemberLiteralCase implements MemberRule {
 
 	ruleName = MemberLiteralCase.name;
 
-	report(_parsedDocument: PslDocument, member: Member): Diagnostic[] {
+	report(_parsedDocument: ProfileComponent, member: Member): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
 		this.checkUpperCase(member, diagnostics);
 		return diagnostics;
@@ -73,7 +73,7 @@ export class MemberCamelCase implements MemberRule {
 
 	ruleName = MemberCamelCase.name;
 
-	report(_parsedDocument: PslDocument, member: Member): Diagnostic[] {
+	report(_parsedDocument: ProfileComponent, member: Member): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
 
 		this.memberCase(member, diagnostics);
@@ -132,7 +132,7 @@ export class MemberLength implements MemberRule {
 
 	ruleName = MemberLength.name;
 
-	report(_parsedDocument: PslDocument, member: Member): Diagnostic[] {
+	report(_parsedDocument: ProfileComponent, member: Member): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
 
 		this.checkMemberLength(member, diagnostics);
@@ -155,7 +155,7 @@ export class MemberStartsWithV implements MemberRule {
 
 	ruleName = MemberStartsWithV.name;
 
-	report(_parsedDocument: PslDocument, member: Member): Diagnostic[] {
+	report(_parsedDocument: ProfileComponent, member: Member): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
 
 		this.checkStartsWithV(member, diagnostics);

--- a/src/pslLint/elementsConventionChecker.ts
+++ b/src/pslLint/elementsConventionChecker.ts
@@ -1,13 +1,12 @@
+import { Member, MemberClass, Method, Property } from '../parser/parser';
 import {
-	Diagnostic, DiagnosticSeverity, Member, MemberClass, MemberRule,
-	Method, MethodRule, ProfileComponent, Property, PropertyRule,
+	Diagnostic, DiagnosticSeverity, MemberRule,
+	MethodRule, PropertyRule,
 } from './api';
 
-export class MethodStartsWithZ implements MethodRule {
+export class MethodStartsWithZ extends MethodRule {
 
-	ruleName = MethodStartsWithZ.name;
-
-	report(_, method: Method): Diagnostic[] {
+	report(method: Method): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
 
 		startsWithZ(method, diagnostics, this.ruleName);
@@ -15,11 +14,9 @@ export class MethodStartsWithZ implements MethodRule {
 		return diagnostics;
 	}
 }
-export class PropertyStartsWithZ implements PropertyRule {
+export class PropertyStartsWithZ extends PropertyRule {
 
-	ruleName = PropertyStartsWithZ.name;
-
-	report(_, property: Property): Diagnostic[] {
+	report(property: Property): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
 
 		startsWithZ(property, diagnostics, this.ruleName);
@@ -28,13 +25,11 @@ export class PropertyStartsWithZ implements PropertyRule {
 	}
 }
 
-export class PropertyIsDummy implements PropertyRule {
+export class PropertyIsDummy extends PropertyRule {
 
-	ruleName = PropertyIsDummy.name;
-
-	report(profileComponent: ProfileComponent, property: Property): Diagnostic[] {
+	report(property: Property): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
-		if (!profileComponent.parsedDocument.extending) {
+		if (!this.parsedDocument.extending) {
 			this.isCalledDummy(property, diagnostics);
 		}
 		return diagnostics;
@@ -49,11 +44,9 @@ export class PropertyIsDummy implements PropertyRule {
 	}
 }
 
-export class MemberLiteralCase implements MemberRule {
+export class MemberLiteralCase extends MemberRule {
 
-	ruleName = MemberLiteralCase.name;
-
-	report(_, member: Member): Diagnostic[] {
+	report(member: Member): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
 		this.checkUpperCase(member, diagnostics);
 		return diagnostics;
@@ -69,11 +62,9 @@ export class MemberLiteralCase implements MemberRule {
 	}
 }
 
-export class MemberCamelCase implements MemberRule {
+export class MemberCamelCase extends MemberRule {
 
-	ruleName = MemberCamelCase.name;
-
-	report(_, member: Member): Diagnostic[] {
+	report(member: Member): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
 
 		this.memberCase(member, diagnostics);
@@ -128,11 +119,9 @@ export class MemberCamelCase implements MemberRule {
 	}
 }
 
-export class MemberLength implements MemberRule {
+export class MemberLength extends MemberRule {
 
-	ruleName = MemberLength.name;
-
-	report(_, member: Member): Diagnostic[] {
+	report(member: Member): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
 
 		this.checkMemberLength(member, diagnostics);
@@ -151,11 +140,9 @@ export class MemberLength implements MemberRule {
 		}
 	}
 }
-export class MemberStartsWithV implements MemberRule {
+export class MemberStartsWithV extends MemberRule {
 
-	ruleName = MemberStartsWithV.name;
-
-	report(_, member: Member): Diagnostic[] {
+	report(member: Member): Diagnostic[] {
 		const diagnostics: Diagnostic[] = [];
 
 		this.checkStartsWithV(member, diagnostics);

--- a/src/pslLint/methodDoc.ts
+++ b/src/pslLint/methodDoc.ts
@@ -12,13 +12,13 @@ export class MethodDocumentation implements MethodRule {
 
 	ruleName = MethodDocumentation.name;
 
-	report(pslDocument: ProfileComponent, method: Method): Diagnostic[] {
+	report(profileComponent: ProfileComponent, method: Method): Diagnostic[] {
 
 		if (method.batch) return [];
 
 		const diagnostics: Diagnostic[] = [];
 
-		if (!hasBlockComment(method, pslDocument)) {
+		if (!hasBlockComment(method, profileComponent)) {
 			const idToken = method.id;
 			const message = `Documentation missing for label "${idToken.value}".`;
 			diagnostics.push(addDiagnostic(idToken, method, message, this.ruleName));
@@ -31,13 +31,13 @@ export class MethodSeparator implements MethodRule {
 
 	ruleName = MethodSeparator.name;
 
-	report(pslDocument: ProfileComponent, method: Method): Diagnostic[] {
+	report(profileComponent: ProfileComponent, method: Method): Diagnostic[] {
 
 		if (method.batch) return [];
 
 		const diagnostics: Diagnostic[] = [];
 
-		if (!hasSeparator(method, pslDocument)) {
+		if (!hasSeparator(method, profileComponent)) {
 			const idToken = method.id;
 			const message = `Separator missing for label "${idToken.value}".`;
 			diagnostics.push(addDiagnostic(idToken, method, message, this.ruleName));
@@ -51,23 +51,23 @@ export class TwoEmptyLines implements MethodRule {
 
 	ruleName = TwoEmptyLines.name;
 
-	report(pslDocument: ProfileComponent, method: Method): Diagnostic[] {
+	report(profileComponent: ProfileComponent, method: Method): Diagnostic[] {
 
 		if (method.batch) return [];
 
 		const diagnostics: Diagnostic[] = [];
 		const idToken = method.id;
 
-		const lineAbove = hasSeparator(method, pslDocument) ? method.id.position.line - 2 : method.id.position.line - 1;
+		const lineAbove = hasSeparator(method, profileComponent) ? method.id.position.line - 2 : method.id.position.line - 1;
 
 		if (lineAbove < 2) {
 			const message = `There should be two empty lines above label "${idToken.value}".`;
 			return [addDiagnostic(idToken, method, message, this.ruleName, Code.TWO_EMPTY_LINES)];
 		}
 
-		const hasOneSpaceAbove: boolean = pslDocument.getTextAtLine(lineAbove).trim() === '';
-		const hasTwoSpacesAbove: boolean = pslDocument.getTextAtLine(lineAbove - 1).trim() === '';
-		const hasThreeSpacesAbove: boolean = pslDocument.getTextAtLine(lineAbove - 2).trim() === '';
+		const hasOneSpaceAbove: boolean = profileComponent.getTextAtLine(lineAbove).trim() === '';
+		const hasTwoSpacesAbove: boolean = profileComponent.getTextAtLine(lineAbove - 1).trim() === '';
+		const hasThreeSpacesAbove: boolean = profileComponent.getTextAtLine(lineAbove - 2).trim() === '';
 
 		let code: Code | undefined;
 		if (!hasTwoSpacesAbove) code = Code.ONE_EMPTY_LINE;
@@ -98,12 +98,12 @@ function addDiagnostic(idToken: Token, method: Method, message: string, ruleName
 	return diagnostic;
 }
 
-function hasSeparator(method: Method, pslDocument: ProfileComponent): boolean {
-	const nextLineCommentTokens: Token[] = pslDocument.getCommentsOnLine(method.id.position.line - 1);
+function hasSeparator(method: Method, profileComponent: ProfileComponent): boolean {
+	const nextLineCommentTokens: Token[] = profileComponent.getCommentsOnLine(method.id.position.line - 1);
 	return nextLineCommentTokens[0] && nextLineCommentTokens[0].isLineComment();
 }
 
-function hasBlockComment(method: Method, pslDocument: ProfileComponent): boolean {
-	const nextLineCommentTokens: Token[] = pslDocument.getCommentsOnLine(getLineAfter(method));
+function hasBlockComment(method: Method, profileComponent: ProfileComponent): boolean {
+	const nextLineCommentTokens: Token[] = profileComponent.getCommentsOnLine(getLineAfter(method));
 	return nextLineCommentTokens[0] && nextLineCommentTokens[0].isBlockComment();
 }

--- a/src/pslLint/methodDoc.ts
+++ b/src/pslLint/methodDoc.ts
@@ -1,7 +1,7 @@
 import { Method, ParsedDocument } from '../parser/parser';
 import { Token } from '../parser/tokenizer';
-import { getLineAfter } from '../parser/utilities';
-import { Diagnostic, DiagnosticSeverity, getCommentsOnLine, MethodRule } from './api';
+import { getCommentsOnLine, getLineAfter} from '../parser/utilities';
+import { Diagnostic, DiagnosticSeverity, MethodRule } from './api';
 
 export enum Code {
 	ONE_EMPTY_LINE = 1,

--- a/src/pslLint/methodDoc.ts
+++ b/src/pslLint/methodDoc.ts
@@ -1,4 +1,4 @@
-import { Diagnostic, DiagnosticSeverity, getLineAfter, Method, MethodRule, PslDocument, Token } from './api';
+import { Diagnostic, DiagnosticSeverity, getLineAfter, Method, MethodRule, ProfileComponent, Token } from './api';
 
 export enum Code {
 	ONE_EMPTY_LINE = 1,
@@ -12,7 +12,7 @@ export class MethodDocumentation implements MethodRule {
 
 	ruleName = MethodDocumentation.name;
 
-	report(pslDocument: PslDocument, method: Method): Diagnostic[] {
+	report(pslDocument: ProfileComponent, method: Method): Diagnostic[] {
 
 		if (method.batch) return [];
 
@@ -31,7 +31,7 @@ export class MethodSeparator implements MethodRule {
 
 	ruleName = MethodSeparator.name;
 
-	report(pslDocument: PslDocument, method: Method): Diagnostic[] {
+	report(pslDocument: ProfileComponent, method: Method): Diagnostic[] {
 
 		if (method.batch) return [];
 
@@ -51,7 +51,7 @@ export class TwoEmptyLines implements MethodRule {
 
 	ruleName = TwoEmptyLines.name;
 
-	report(pslDocument: PslDocument, method: Method): Diagnostic[] {
+	report(pslDocument: ProfileComponent, method: Method): Diagnostic[] {
 
 		if (method.batch) return [];
 
@@ -98,12 +98,12 @@ function addDiagnostic(idToken: Token, method: Method, message: string, ruleName
 	return diagnostic;
 }
 
-function hasSeparator(method: Method, pslDocument: PslDocument): boolean {
+function hasSeparator(method: Method, pslDocument: ProfileComponent): boolean {
 	const nextLineCommentTokens: Token[] = pslDocument.getCommentsOnLine(method.id.position.line - 1);
 	return nextLineCommentTokens[0] && nextLineCommentTokens[0].isLineComment();
 }
 
-function hasBlockComment(method: Method, pslDocument: PslDocument): boolean {
+function hasBlockComment(method: Method, pslDocument: ProfileComponent): boolean {
 	const nextLineCommentTokens: Token[] = pslDocument.getCommentsOnLine(getLineAfter(method));
 	return nextLineCommentTokens[0] && nextLineCommentTokens[0].isBlockComment();
 }

--- a/src/pslLint/multiLineDeclare.ts
+++ b/src/pslLint/multiLineDeclare.ts
@@ -1,12 +1,10 @@
-import {
-	Declaration, Diagnostic, DiagnosticSeverity, getTokens,
-	Method, MethodRule, NON_TYPE_MODIFIERS, ProfileComponent,
-} from './api';
+import { Declaration, Method, NON_TYPE_MODIFIERS } from '../parser/parser';
+import { getTokens } from '../parser/tokenizer';
+import { Diagnostic, DiagnosticSeverity, MethodRule } from './api';
 
-export class MultiLineDeclare implements MethodRule {
-	ruleName = MultiLineDeclare.name;
+export class MultiLineDeclare extends MethodRule {
 
-	report(profileComponent: ProfileComponent, method: Method): Diagnostic[] {
+	report(method: Method): Diagnostic[] {
 
 		const diagnostics: Diagnostic[] = [];
 		let reportVariable: boolean = false;
@@ -14,7 +12,7 @@ export class MultiLineDeclare implements MethodRule {
 		const multiLineDeclarations = this.getMultiLineDeclarations(method.declarations);
 
 		multiLineDeclarations.forEach((declarationsOnLine, lineNumber) => {
-			const fullLine = profileComponent.getTextAtLine(lineNumber);
+			const fullLine = this.profileComponent.getTextAtLine(lineNumber);
 			if (!(fullLine.includes('=') && fullLine.includes(','))) return;
 			for (const declaration of declarationsOnLine) {
 				reportVariable = false;

--- a/src/pslLint/multiLineDeclare.ts
+++ b/src/pslLint/multiLineDeclare.ts
@@ -1,12 +1,12 @@
 import {
 	Declaration, Diagnostic, DiagnosticSeverity, getTokens,
-	Method, MethodRule, NON_TYPE_MODIFIERS, PslDocument,
+	Method, MethodRule, NON_TYPE_MODIFIERS, ProfileComponent,
 } from './api';
 
 export class MultiLineDeclare implements MethodRule {
 	ruleName = MultiLineDeclare.name;
 
-	report(pslDocument: PslDocument, method: Method): Diagnostic[] {
+	report(pslDocument: ProfileComponent, method: Method): Diagnostic[] {
 
 		const diagnostics: Diagnostic[] = [];
 		let reportVariable: boolean = false;

--- a/src/pslLint/multiLineDeclare.ts
+++ b/src/pslLint/multiLineDeclare.ts
@@ -6,7 +6,7 @@ import {
 export class MultiLineDeclare implements MethodRule {
 	ruleName = MultiLineDeclare.name;
 
-	report(pslDocument: ProfileComponent, method: Method): Diagnostic[] {
+	report(profileComponent: ProfileComponent, method: Method): Diagnostic[] {
 
 		const diagnostics: Diagnostic[] = [];
 		let reportVariable: boolean = false;
@@ -14,7 +14,7 @@ export class MultiLineDeclare implements MethodRule {
 		const multiLineDeclarations = this.getMultiLineDeclarations(method.declarations);
 
 		multiLineDeclarations.forEach((declarationsOnLine, lineNumber) => {
-			const fullLine = pslDocument.getTextAtLine(lineNumber);
+			const fullLine = profileComponent.getTextAtLine(lineNumber);
 			if (!(fullLine.includes('=') && fullLine.includes(','))) return;
 			for (const declaration of declarationsOnLine) {
 				reportVariable = false;

--- a/src/pslLint/parameters.ts
+++ b/src/pslLint/parameters.ts
@@ -1,13 +1,12 @@
-import { Diagnostic, DiagnosticSeverity, Method, MethodRule, Parameter } from './api';
+import { Method, Parameter } from '../parser/parser';
+import { Diagnostic, DiagnosticSeverity, MethodRule } from './api';
 
 /**
  * Checks if multiple parameters are written on the same line as the method declaration.
  */
-export class MethodParametersOnNewLine implements MethodRule {
+export class MethodParametersOnNewLine extends MethodRule {
 
-	ruleName = MethodParametersOnNewLine.name;
-
-	report(_, method: Method): Diagnostic[] {
+	report(method: Method): Diagnostic[] {
 
 		if (method.batch) return [];
 

--- a/src/pslLint/parameters.ts
+++ b/src/pslLint/parameters.ts
@@ -1,4 +1,4 @@
-import { Diagnostic, DiagnosticSeverity, Method, MethodRule, Parameter, PslDocument } from './api';
+import { Diagnostic, DiagnosticSeverity, Method, MethodRule, Parameter, ProfileComponent } from './api';
 
 /**
  * Checks if multiple parameters are written on the same line as the method declaration.
@@ -7,7 +7,7 @@ export class MethodParametersOnNewLine implements MethodRule {
 
 	ruleName = MethodParametersOnNewLine.name;
 
-	report(_pslDocument: PslDocument, method: Method): Diagnostic[] {
+	report(_pslDocument: ProfileComponent, method: Method): Diagnostic[] {
 
 		if (method.batch) return [];
 

--- a/src/pslLint/parameters.ts
+++ b/src/pslLint/parameters.ts
@@ -1,4 +1,4 @@
-import { Diagnostic, DiagnosticSeverity, Method, MethodRule, Parameter, ProfileComponent } from './api';
+import { Diagnostic, DiagnosticSeverity, Method, MethodRule, Parameter } from './api';
 
 /**
  * Checks if multiple parameters are written on the same line as the method declaration.
@@ -7,7 +7,7 @@ export class MethodParametersOnNewLine implements MethodRule {
 
 	ruleName = MethodParametersOnNewLine.name;
 
-	report(_pslDocument: ProfileComponent, method: Method): Diagnostic[] {
+	report(_, method: Method): Diagnostic[] {
 
 		if (method.batch) return [];
 

--- a/src/pslLint/runtime.ts
+++ b/src/pslLint/runtime.ts
@@ -4,13 +4,13 @@ import {
 } from '../parser/statementParser';
 import {
 	Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity,
-	Member, MemberClass, Method, MethodRule, PslDocument, Range, Token,
+	Member, MemberClass, Method, MethodRule, ProfileComponent, Range, Token,
 } from './api';
 
 export class RuntimeStart implements MethodRule {
 	ruleName = RuntimeStart.name;
 
-	report(pslDocument: PslDocument, method: Method): Diagnostic[] {
+	report(pslDocument: ProfileComponent, method: Method): Diagnostic[] {
 
 		const runtimeCalls: BinaryOperator[] = [];
 
@@ -44,7 +44,7 @@ export class RuntimeStart implements MethodRule {
 		return dotOperator.right as Identifier;
 	}
 
-	tpFence(diagnostics: Diagnostic[], runtimeCalls: BinaryOperator[], pslDocument: PslDocument, method: Method) {
+	tpFence(diagnostics: Diagnostic[], runtimeCalls: BinaryOperator[], pslDocument: ProfileComponent, method: Method) {
 		let lastStart: Value;
 		let variables: Map<Member, Token[]>;
 		let acceptVariables: string[] = [];
@@ -150,7 +150,7 @@ export class RuntimeStart implements MethodRule {
 		return new Range(start.id.position.line, startPos, start.id.position.line, endPos);
 	}
 
-	private addToWhitelist(pslDocument: PslDocument, runtimeMethod: Identifier) {
+	private addToWhitelist(pslDocument: ProfileComponent, runtimeMethod: Identifier) {
 		let acceptVariables = [];
 		const commentsAbove: Token[] = pslDocument.getCommentsOnLine(runtimeMethod.id.position.line - 1);
 		const whiteListComment = commentsAbove[0];

--- a/src/pslLint/runtime.ts
+++ b/src/pslLint/runtime.ts
@@ -4,10 +4,8 @@ import {
 	StringLiteral, SyntaxKind, Value,
 } from '../parser/statementParser';
 import { Range, Token } from '../parser/tokenizer';
-import {
-	Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity,
-	getCommentsOnLine, MethodRule,
-} from './api';
+import { getCommentsOnLine } from '../parser/utilities';
+import { Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, MethodRule } from './api';
 
 export class RuntimeStart extends MethodRule {
 

--- a/src/pslLint/todos.ts
+++ b/src/pslLint/todos.ts
@@ -1,10 +1,10 @@
-import { Diagnostic, DiagnosticSeverity, DocumentRule, getTokens, Position, PslDocument, Range } from './api';
+import { Diagnostic, DiagnosticSeverity, ProfileComponentRule, getTokens, Position, ProfileComponent, Range } from './api';
 
-export class TodoInfo implements DocumentRule {
+export class TodoInfo implements ProfileComponentRule {
 
 	ruleName = TodoInfo.name;
 
-	report(pslDocument: PslDocument): Diagnostic[] {
+	report(pslDocument: ProfileComponent): Diagnostic[] {
 		let todos: Todo[] = [];
 		for (const token of pslDocument.parsedDocument.comments) {
 			if (token.value.includes('TODO')) {

--- a/src/pslLint/todos.ts
+++ b/src/pslLint/todos.ts
@@ -1,12 +1,15 @@
-import { Diagnostic, DiagnosticSeverity, ProfileComponentRule, getTokens, Position, ProfileComponent, Range } from './api';
+import {
+	Diagnostic, DiagnosticSeverity, getTokens, Position,
+	ProfileComponent, ProfileComponentRule, Range,
+} from './api';
 
 export class TodoInfo implements ProfileComponentRule {
 
 	ruleName = TodoInfo.name;
 
-	report(pslDocument: ProfileComponent): Diagnostic[] {
+	report(profileComponent: ProfileComponent): Diagnostic[] {
 		let todos: Todo[] = [];
-		for (const token of pslDocument.parsedDocument.comments) {
+		for (const token of profileComponent.parsedDocument.comments) {
 			if (token.value.includes('TODO')) {
 				const startLine = token.position.line;
 				const startChar = token.position.character;

--- a/src/pslLint/todos.ts
+++ b/src/pslLint/todos.ts
@@ -1,15 +1,11 @@
-import {
-	Diagnostic, DiagnosticSeverity, getTokens, Position,
-	ProfileComponent, ProfileComponentRule, Range,
-} from './api';
+import { getTokens, Position, Range } from '../parser/tokenizer';
+import { Diagnostic, DiagnosticSeverity, PslRule } from './api';
 
-export class TodoInfo implements ProfileComponentRule {
+export class TodoInfo extends PslRule {
 
-	ruleName = TodoInfo.name;
-
-	report(profileComponent: ProfileComponent): Diagnostic[] {
+	report(): Diagnostic[] {
 		let todos: Todo[] = [];
-		for (const token of profileComponent.parsedDocument.comments) {
+		for (const token of this.parsedDocument.comments) {
 			if (token.value.includes('TODO')) {
 				const startLine = token.position.line;
 				const startChar = token.position.character;


### PR DESCRIPTION
Allows for the linting for non-PSL elements. As of now this only is extended to TBL and COL, but more types can be allowed in the future.