### PR TITLE
Allow specification of serverType and encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Locate the button at the bottom-right corner titled `Configure Environments`. If
 }
 ```
 
-> Added in v1.8.0 are the fields `serverType` and `encoding`. Their default values are "SCA$IBS" and "utf8", respectively. Use intellisense while editing the configuration file for more details.
+> Added in v1.8.0 are the fields `serverType` and `encoding`. Their default values are "SCA$IBS" and "utf8", respectively.
 
 Here you can store a global array of configurations. Any project can read from this configuration. Use auto-complete and hover suggestions for hints about using the configuration file.
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,16 @@ Locate the button at the bottom-right corner titled `Configure Environments`. If
 			"port": 0,
 			"user": "",
 			"password": "",
-			"sshLogin": ""
+			"sshLogin": "",
+			"serverType": "SCA$IBS",   // added v1.8.0
+			"encoding": "utf8"         // added v1.8.0
 		}
 	]
 }
 ```
+
+> Added in v1.8.0 are the fields `serverType` and `encoding`. Their default values are "SCA$IBS" and "utf8", respectively. Use intellisense while editing the configuration file for more details.
+
 Here you can store a global array of configurations. Any project can read from this configuration. Use auto-complete and hover suggestions for hints about using the configuration file.
 
 Once the global configuration is saved, environments can be activated by using the `Configure Environments` button at the bottom. Multiple environments can be selected, allowing for simultaneous interactions with hosts.

--- a/schemas/environmentsSchema.json
+++ b/schemas/environmentsSchema.json
@@ -7,7 +7,16 @@
 			"type": "array",
 			"description": "A list of all available environments.",
 			"items": {
-				"default": {"name": "" , "host": "" , "port": 0, "user": "" , "password": "" , "sshLogin": "" },
+				"default": {
+					"name": "",
+					"host": "",
+					"port": 0,
+					"user": "",
+					"password": "",
+					"sshLogin": "",
+					"serverType": "SCA$IBS",
+					"encoding": "utf8"
+				},
 				"properties": {
 					"name": {
 						"type": "string",
@@ -40,9 +49,9 @@
 					"encoding": {
 						"type": "string",
 						"description": "Encoding to use in request/response. The default value is \"utf8\".",
-						"enum": ["ascii", "utf8", "utf16le", "ucs2", "base64", "latin1", "binary", "hex"]
+						"enum": ["ascii", "utf8", "ucs2", "base64", "latin1", "binary", "hex"]
 					}
-				}				
+				}
 			}
 		}
 	},

--- a/schemas/environmentsSchema.json
+++ b/schemas/environmentsSchema.json
@@ -32,6 +32,15 @@
 					"sshLogin": {
 						"type": "string",
 						"description": "The login used to ssh into the Profile Server."
+					},
+					"serverType": {
+						"type": "string",
+						"description": "The server type. Default value is \"SCA$IBS\"."
+					},
+					"encoding": {
+						"type": "string",
+						"description": "Encoding to use in request/response. The default value is \"utf8\".",
+						"enum": ["ascii", "utf8", "utf16le", "ucs2", "base64", "latin1", "binary", "hex"]
 					}
 				}				
 			}

--- a/src/common/environment.ts
+++ b/src/common/environment.ts
@@ -54,7 +54,7 @@ export async function workspaceQuickPick(): Promise<WorkspaceQuickPick | undefin
 		await GlobalFile.read();
 	}
 	catch (e) {
-		let defaultConfig: GlobalConfig = { environments: [{ name: '', host: '', port: 0, user: '', password: '', sshLogin: '' }] }
+		let defaultConfig: GlobalConfig = { environments: [{ name: '', host: '', port: 0, user: '', password: '', sshLogin: '', serverType: 'SCA$IBS', encoding: 'utf8' }] }
 		await GlobalFile.write(defaultConfig);
 		await GlobalFile.show();
 		return;

--- a/src/common/environment.ts
+++ b/src/common/environment.ts
@@ -27,12 +27,14 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 export interface EnvironmentConfig {
-	name: string,
-	host: string,
-	port: number,
-	user: string,
-	password: string,
-	sshLogin: string
+	name: string;
+	host: string;
+	port: number;
+	user: string;
+	password: string;
+	sshLogin?: string;
+	serverType?: string;
+	encoding?: BufferEncoding;
 }
 
 interface GlobalConfig {

--- a/src/hostCommands/hostCommandUtils.ts
+++ b/src/hostCommands/hostCommandUtils.ts
@@ -88,7 +88,7 @@ export async function executeWithProgress(message: string, task: () => Promise<a
 export async function getConnection(env: environment.EnvironmentConfig): Promise<MtmConnection> {
 	let connection: MtmConnection;
 	try {
-		connection = MtmConnection.getSocket('121', 3);
+		connection = MtmConnection.getSocket('121', 3, env.serverType, env.encoding);
 		await connection.open(env.host, env.port, env.user, env.password);
 	}
 	catch (err) {

--- a/src/mtm/mtm.ts
+++ b/src/mtm/mtm.ts
@@ -163,7 +163,7 @@ export class MtmConnection {
 			let partialString: string = fileString.slice(i * 1024, (i * 1024) + 1024);
 			let withPipe: string = '';
 			for (const char of partialString) {
-				withPipe += (char.charCodeAt(0) + '|');
+				withPipe += char.charCodeAt(0) + '|';
 			}
 			let prepareString: string = utils.initCodeObject(withPipe, codeToken)
 			returnString = await this.execute(this.serviceClass, prepareString)

--- a/src/mtm/mtm.ts
+++ b/src/mtm/mtm.ts
@@ -13,7 +13,8 @@ export class MtmConnection {
 	private mrpcId: string;
 
 	private socket: HostSocket = new HostSocket()
-	private servertype: string = 'SCA$IBS';
+	private serverType: string = 'SCA$IBS';
+	private encoding: BufferEncoding = 'utf8';
 	private messageByte: string = String.fromCharCode(28);
 	private token: string = '';
 	private messageId: number = 0;
@@ -22,13 +23,15 @@ export class MtmConnection {
 	private isSql: boolean = false;
 	private recordCount: number = 0;
 
-	private constructor(mrpcId: string, serviceClass: number) {
+	private constructor(mrpcId: string, serviceClass: number, serverType?: string, encoding?: BufferEncoding) {
 		this.mrpcId = mrpcId;
 		this.serviceClass = serviceClass;
+		if (serverType) this.serverType = serverType;
+		if (encoding) this.encoding = encoding;
 	}
 
-	static getSocket(mrpcId: string, serviceClass: number) {
-		return new MtmConnection(mrpcId, serviceClass);
+	static getSocket(mrpcId: string, serviceClass: number, servertype?: string, encoding?: BufferEncoding) {
+		return new MtmConnection(mrpcId, serviceClass, servertype, encoding);
 	}
 
 	async open(host: string, port: number, profileUsername: string, profilePassword: string) {
@@ -152,16 +155,16 @@ export class MtmConnection {
 
 	private async sendToProfile(filename: string) {
 		let returnString: string;
-		let fileString: Buffer = await readFileAsync(filename);
+		let fileString: string = await readFileAsync(filename, {encoding: this.encoding}) as string;
 		let fileContentLength: number = fileString.length;
 		let totalLoop: number = Math.ceil(fileContentLength / 1024);
 		let codeToken: string = '';
 		for (let i = 0; i < totalLoop; i++) {
-			let partialBufferString: Buffer = fileString.slice(i * 1024, (i * 1024) + 1024);
+			let partialString: string = fileString.slice(i * 1024, (i * 1024) + 1024);
 			let withPipe: string = '';
-			partialBufferString.forEach(eachChar => {
-				withPipe = withPipe.concat(eachChar.toString().concat('|'));
-			})
+			for (const char of partialString) {
+				withPipe += (char.charCodeAt(0) + '|');
+			}
 			let prepareString: string = utils.initCodeObject(withPipe, codeToken)
 			returnString = await this.execute(this.serviceClass, prepareString)
 			codeToken = returnString;
@@ -321,7 +324,7 @@ export class MtmConnection {
 			messageLength = messageLength + nextMessage.length;
 			message = Buffer.concat([message, nextMessage], messageLength)
 		}
-		return (utils.parseResponse(serviceClass, message.slice(3, message.length)));
+		return (utils.parseResponse(serviceClass, message.slice(3, message.length), this.encoding));
 	}
 
 	private prepareSendingMessage(serviceClass: number, prepareString: string): string {
@@ -331,14 +334,14 @@ export class MtmConnection {
 			prepareString = utils.mrpcMessage(this.mrpcId, version.toString(), prepareString)
 		}
 		let sendingMessage = utils.sendingMessage(tokenMessage, prepareString);
-		sendingMessage = this.servertype + this.messageByte + sendingMessage
+		sendingMessage = this.serverType + this.messageByte + sendingMessage
 		sendingMessage = utils.pack(sendingMessage.length + 2) + sendingMessage;
 		this.messageId++;
 		return sendingMessage;
 	}
 }
 
-function readFileAsync(file: string, options?: any): Promise<Buffer> {
+function readFileAsync(file: string, options?: {encoding?: string, flag?: string}): Promise<Buffer | string> {
 	return new Promise((resolve, reject) => {
 		fs.readFile(file, options, (err, data) => {
 			if (err) {

--- a/src/mtm/utils.ts
+++ b/src/mtm/utils.ts
@@ -114,19 +114,19 @@ export function lv2vFormat(messageString: Buffer): Buffer[] {
 		return returnString
 	}
 
-export function parseResponse(serviceClass: number, outputData: Buffer): string {
+export function parseResponse(serviceClass: number, outputData: Buffer, encoding: BufferEncoding): string {
 		// unpacking multiple times to get the token, remove the endiness by extracting from position 2
 		let returnString: string = ''
 		let returnArray: Buffer[];
 		returnArray = lv2vFormat(outputData);
 		returnArray = lv2vFormat(returnArray[1]);
 		returnArray = lv2vFormat(returnArray[1]);
-		returnString = returnArray[0].toString()
+		returnString = returnArray[0].toString(encoding)
 		if (returnString === 'ER') {
-			throw returnArray.map(x => x.toString()).join('')
+			throw returnArray.map(x => x.toString(encoding)).join('')
 		}
 		if (serviceClass === 5) {
-			returnString = returnArray[2].toString() + String.fromCharCode(0) + returnArray[3].toString()
+			returnString = returnArray[2].toString(encoding) + String.fromCharCode(0) + returnArray[3].toString(encoding)
 		}
 		return returnString;
 	}


### PR DESCRIPTION
Fixes #57

These new settings can be defined in the environments.json file.

Also fixes an issue were characters represented by more than one byte were split when being sent to Host.