### PR TITLE
Send debug commands to active terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,6 +178,21 @@
         "category": "PSL"
       },
       {
+        "command": "psl.stepOut",
+        "title": "Terminal Step Out",
+        "category": "PSL"
+      },
+      {
+        "command": "psl.stepIn",
+        "title": "Terminal Step In",
+        "category": "PSL"
+      },
+      {
+        "command": "psl.stepOver",
+        "title": "Terminal Step Over",
+        "category": "PSL"
+      },
+      {
         "command": "psl.getElement",
         "title": "Get Element from Host",
         "category": "PSL"
@@ -721,21 +736,6 @@
       {
         "command": "psl.launchHostTerminal",
         "key": "win+oem_3"
-      },
-      {
-        "key": "Ctrl+E",
-        "command": "psl.stepOut",
-        "when": "terminalFocus && psl.hasHostTerminal"
-      },
-      {
-        "key": "Ctrl+Q",
-        "command": "psl.stepIn",
-        "when": "terminalFocus && psl.hasHostTerminal"
-      },
-      {
-        "key": "Ctrl+W",
-        "command": "psl.stepOver",
-        "when": "terminalFocus && psl.hasHostTerminal"
       }
     ],
     "configuration": {

--- a/src/common/terminal.ts
+++ b/src/common/terminal.ts
@@ -129,8 +129,8 @@ function sendToHostTerminal(text: string) {
 }
 
 function terminalSend(text: string) {
-	if (terminal) {
-		terminal.show();
-		terminal.sendText(text, true);
+	const activeTerminal: vscode.Terminal | undefined = vscode.window.activeTerminal;
+	if (activeTerminal) {
+		activeTerminal.sendText(text, true);
 	}
 }


### PR DESCRIPTION
This will be a breaking change, as the existing keyboard shortcuts will have to be retired.

This is necessary in order to prevent any unexpected behavior.