### PR TITLE
Added default snippet for pslmain()

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     },
     "search.exclude": {
         "out": true // set this to false to include "out" folder in search results
-    }
+    },
+    "editor.rulers": [120] // Recommended typescript ruler
 }

--- a/snippets/psl.json
+++ b/snippets/psl.json
@@ -59,6 +59,20 @@
 			"\t$0",
 			"\t** ENDDOC */"
 		],
-		"description": "Adds a method stub with a documentation comment block"
+		"description": "Adds a method stub with a documentation comment block."
+	},
+	"pslmain":{
+		"prefix": "psip",
+		"body": [
+			"\t// --------------------------------------------------------------------",
+			"public static Integer plsmain(void args(String))",
+			"\t/* DOC ----------------------------------------------------------------",
+			"\tCommand line entry point.",
+			"",
+			"\t@param\targs\tCommand line arguments",
+			"\t** ENDDOC */",
+			"\treturn 0"
+		],
+		"description": "Add the method signature for a pslmain method."
 	}
 }

--- a/snippets/psl.json
+++ b/snippets/psl.json
@@ -71,6 +71,7 @@
 			"",
 			"\t@param\targs\tCommand line arguments",
 			"\t** ENDDOC */",
+			"\t$0",
 			"\treturn 0"
 		],
 		"description": "Add the method signature for a pslmain method."


### PR DESCRIPTION
Added a snippet to have a default `pslmain()` method:

```
	// --------------------------------------------------------------------
public static Integer pslmain(void args(String))
	/* DOC ----------------------------------------------------------------
	Command line entry point.

	@param	args	Command line arguments
	** ENDDOC */
	return 0
```