### PR TITLE
Added ability to go to a method in another file

### DIFF
--- a/__tests__/files/ZProcedureName.PROC
+++ b/__tests__/files/ZProcedureName.PROC
@@ -1,0 +1,10 @@
+	#CLASSDEF public
+
+	#PROPERTYDEF	dummy					class = String	position = 2
+
+private void String methodName()
+	type String value = $$value()
+	quit
+
+private String value()
+	return "X"

--- a/__tests__/utilities-test.ts
+++ b/__tests__/utilities-test.ts
@@ -115,7 +115,93 @@ describe('completion', () => {
 	});
 });
 
-describe('ParsedDocFinder', () => {
+describe('ParsedDocFinder.resolveResult', () => {
+	let filesDir: string;
+
+	let parentFilePath: string;
+	let procedureNameFilePath: string;
+
+	let parsedParent: ParsedDocument;
+
+	beforeAll(async () => {
+		filesDir = path.resolve('__tests__', 'files');
+
+		parentFilePath = path.join(filesDir, 'ZParent.PROC');
+		procedureNameFilePath = path.join(filesDir, 'ZProcedureName.PROC');
+
+		parsedParent = await parseFile(parentFilePath);
+	});
+
+	test('Find local method', async () => {
+		const paths: utilities.FinderPaths = {
+			corePsl: '',
+			projectPsl: [filesDir],
+			routine: parentFilePath,
+			table: '',
+		};
+		const finder: utilities.ParsedDocFinder = new utilities.ParsedDocFinder(parsedParent, paths);
+		let result = await finder.resolveResult([
+			new tokenizer.Token(tokenizer.Type.Alphanumeric, 'methodInParent', { character: 15, line: 4 })
+		]);
+		expect(result).toBeDefined();
+		expect(result.member.memberClass).toBe(MemberClass.method);
+		expect(result.member.id.value).toBe('methodInParent');
+		expect(result.fsPath).toBe(parentFilePath);
+	});
+
+	test('Find method in current procedure', async () => {
+		const paths: utilities.FinderPaths = {
+			corePsl: '',
+			projectPsl: [filesDir],
+			routine: parentFilePath,
+			table: '',
+		};
+		const finder: utilities.ParsedDocFinder = new utilities.ParsedDocFinder(parsedParent, paths);
+		let result = await finder.resolveResult([
+			new tokenizer.Token(tokenizer.Type.Alphanumeric, 'ZParent', { character: 26, line: 4 }),
+			new tokenizer.Token(tokenizer.Type.Alphanumeric, 'methodInParent', { character: 15, line: 4 })
+		]);
+		expect(result).toBeDefined();
+		expect(result.member.memberClass).toBe(MemberClass.method);
+		expect(result.member.id.value).toBe('methodInParent');
+		expect(result.fsPath).toBe(parentFilePath);
+	});
+
+	test('Find method in external procedure', async () => {
+		const paths: utilities.FinderPaths = {
+			corePsl: '',
+			projectPsl: [filesDir],
+			routine: parentFilePath,
+			table: '',
+		};
+		const finder: utilities.ParsedDocFinder = new utilities.ParsedDocFinder(parsedParent, paths);
+		let result = await finder.resolveResult([
+			new tokenizer.Token(tokenizer.Type.Alphanumeric, 'ZProcedureName', { character: 26, line: 4 }),
+			new tokenizer.Token(tokenizer.Type.Alphanumeric, 'methodName', { character: 15, line: 4 })
+		]);
+		expect(result).toBeDefined();
+		expect(result.member.memberClass).toBe(MemberClass.method);
+		expect(result.member.id.value).toBe('methodName');
+		expect(result.fsPath).toBe(procedureNameFilePath);
+	});
+
+	test('Find external procedure', async () => {
+		const paths: utilities.FinderPaths = {
+			corePsl: '',
+			projectPsl: [filesDir],
+			routine: parentFilePath,
+			table: '',
+		};
+		const finder: utilities.ParsedDocFinder = new utilities.ParsedDocFinder(parsedParent, paths);
+		let result = await finder.resolveResult([
+			new tokenizer.Token(tokenizer.Type.Alphanumeric, 'ZProcedureName', { character: 26, line: 4 })
+		]);
+		expect(result).toBeDefined();
+		expect(result.fsPath).toBe(procedureNameFilePath);
+	});
+});
+
+describe('ParsedDocFinder.searchParser', () => {
 	let filesDir: string;
 
 	let parentFilePath: string;

--- a/__tests__/utilities-test.ts
+++ b/__tests__/utilities-test.ts
@@ -8,6 +8,17 @@ function getTokens(str: string): tokenizer.Token[] {
 	return [...tokenizer.getTokens(str)];
 }
 
+const filesDir = path.resolve('__tests__', 'files');
+
+const getPaths = (activeRoutine: string): FinderPaths => {
+	return {
+		activeRoutine,
+		corePsl: '',
+		projectPsl: [filesDir],
+		tables: [],
+	};
+};
+
 describe('completion', () => {
 	test('empty', () => {
 		const tokensOnLine: tokenizer.Token[] = [];
@@ -117,7 +128,6 @@ describe('completion', () => {
 });
 
 describe('ParsedDocFinder.resolveResult', () => {
-	let filesDir: string;
 
 	let parentFilePath: string;
 	let procedureNameFilePath: string;
@@ -125,7 +135,6 @@ describe('ParsedDocFinder.resolveResult', () => {
 	let parsedParent: ParsedDocument;
 
 	beforeAll(async () => {
-		filesDir = path.resolve('__tests__', 'files');
 
 		parentFilePath = path.join(filesDir, 'ZParent.PROC');
 		procedureNameFilePath = path.join(filesDir, 'ZProcedureName.PROC');
@@ -134,12 +143,7 @@ describe('ParsedDocFinder.resolveResult', () => {
 	});
 
 	test('Find local method', async () => {
-		const paths: utilities.FinderPaths = {
-			corePsl: '',
-			projectPsl: [filesDir],
-			routine: parentFilePath,
-			table: '',
-		};
+		const paths = getPaths(parentFilePath);
 		const finder: utilities.ParsedDocFinder = new utilities.ParsedDocFinder(parsedParent, paths);
 		let result = await finder.resolveResult([
 			new tokenizer.Token(tokenizer.Type.Alphanumeric, 'methodInParent', { character: 15, line: 4 })
@@ -151,12 +155,7 @@ describe('ParsedDocFinder.resolveResult', () => {
 	});
 
 	test('Find method in current procedure', async () => {
-		const paths: utilities.FinderPaths = {
-			corePsl: '',
-			projectPsl: [filesDir],
-			routine: parentFilePath,
-			table: '',
-		};
+		const paths = getPaths(parentFilePath);
 		const finder: utilities.ParsedDocFinder = new utilities.ParsedDocFinder(parsedParent, paths);
 		let result = await finder.resolveResult([
 			new tokenizer.Token(tokenizer.Type.Alphanumeric, 'ZParent', { character: 26, line: 4 }),
@@ -169,12 +168,7 @@ describe('ParsedDocFinder.resolveResult', () => {
 	});
 
 	test('Find method in external procedure', async () => {
-		const paths: utilities.FinderPaths = {
-			corePsl: '',
-			projectPsl: [filesDir],
-			routine: parentFilePath,
-			table: '',
-		};
+		const paths = getPaths(parentFilePath);
 		const finder: utilities.ParsedDocFinder = new utilities.ParsedDocFinder(parsedParent, paths);
 		let result = await finder.resolveResult([
 			new tokenizer.Token(tokenizer.Type.Alphanumeric, 'ZProcedureName', { character: 26, line: 4 }),
@@ -187,12 +181,7 @@ describe('ParsedDocFinder.resolveResult', () => {
 	});
 
 	test('Find external procedure', async () => {
-		const paths: utilities.FinderPaths = {
-			corePsl: '',
-			projectPsl: [filesDir],
-			routine: parentFilePath,
-			table: '',
-		};
+		const paths = getPaths(parentFilePath);
 		const finder: utilities.ParsedDocFinder = new utilities.ParsedDocFinder(parsedParent, paths);
 		let result = await finder.resolveResult([
 			new tokenizer.Token(tokenizer.Type.Alphanumeric, 'ZProcedureName', { character: 26, line: 4 })
@@ -203,7 +192,6 @@ describe('ParsedDocFinder.resolveResult', () => {
 });
 
 describe('ParsedDocFinder.searchParser', () => {
-	let filesDir: string;
 
 	let parentFilePath: string;
 	let childFilePath: string;
@@ -211,17 +199,7 @@ describe('ParsedDocFinder.searchParser', () => {
 	let parsedParent: ParsedDocument;
 	let parsedChild: ParsedDocument;
 
-	const getPaths = (activeRoutine: string): FinderPaths => {
-		return {
-			activeRoutine,
-			corePsl: '',
-			projectPsl: [filesDir],
-			tables: [],
-		};
-	}
-
 	beforeAll(async () => {
-		filesDir = path.resolve('__tests__', 'files');
 
 		parentFilePath = path.join(filesDir, 'ZParent.PROC');
 		childFilePath = path.join(filesDir, 'ZChild.PROC');

--- a/src/parser/utilities.ts
+++ b/src/parser/utilities.ts
@@ -64,12 +64,12 @@ export class ParsedDocFinder {
 						fsPath: this.paths.activeRoutine,
 					};
 				}
-				
+
 				// naive check for custom procedures (does it match an existing psl file?)
 				finder = await finder.newFinder(callTokens[0].value);
 				if (finder) {
 					return {
-						fsPath: finder.paths.routine,
+						fsPath: finder.paths.activeRoutine,
 					};
 				}
 			}
@@ -106,7 +106,7 @@ export class ParsedDocFinder {
 					else {
 						result = await finder.searchParser(token);
 					}
-				
+
 					// naive check for custom procedures (does it match an existing psl file?)
 					let procedureFinder = await finder.newFinder(callTokens[0].value);
 					if (procedureFinder) {

--- a/src/parser/utilities.ts
+++ b/src/parser/utilities.ts
@@ -69,6 +69,14 @@ export class ParsedDocFinder {
 						fsPath: this.paths.routine,
 					};
 				}
+				
+				// naive check for custom procedures (does it match an existing psl file?)
+				finder = await finder.newFinder(callTokens[0].value);
+				if (finder) {
+					return {
+						fsPath: finder.paths.routine,
+					};
+				}
 			}
 
 			// handle static types
@@ -103,6 +111,13 @@ export class ParsedDocFinder {
 					else {
 						result = await finder.searchParser(token);
 					}
+				
+					// naive check for custom procedures (does it match an existing psl file?)
+					let procedureFinder = await finder.newFinder(callTokens[0].value);
+					if (procedureFinder) {
+						finder = procedureFinder;
+						continue;
+					}
 				}
 
 				if (!result || (result.fsPath === this.paths.routine && !result.member)) {
@@ -119,7 +134,7 @@ export class ParsedDocFinder {
 	}
 
 	async newFinder(routineName: string): Promise<ParsedDocFinder | undefined> {
-
+		
 		if (routineName.startsWith('Record') && routineName !== 'Record') {
 			const tableName = routineName.replace('Record', '');
 			const tableDirectory = path.join(this.paths.table, tableName.toLowerCase());


### PR DESCRIPTION
Includes unit tests. The first token provided to resolveResult is checked to see if it matches an existing procedure file name. If so, then any subsequent tokens are looked for in that file.