### PR TITLE
Fix Bug in `mtm.ts` with Buffer and string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the "vscode-psl" extension will be documented in this
 file.
 
+## v1.12.1
+
+* Fix of bug where `Buffer` was not decoded to a `string`.
+
 ## v1.12.0
 
 * Update dependencies.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Profile Scripting Language functionality for Visual Studio Code.
 
 ## Dependencies
 
-* Visual Studio Code version 1.29 or higher.
+* Visual Studio Code version 1.72.2 or higher.
 
 ## Environment Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-psl",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-psl",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-psl",
   "displayName": "vscode-psl",
   "description": "Profile Scripting Language support",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "preview": true,
   "publisher": "ing-bank",
   "engines": {

--- a/src/mtm/mtm.ts
+++ b/src/mtm/mtm.ts
@@ -158,7 +158,7 @@ export class MtmConnection {
 
 	private async _send(filename: string) {
 		let returnString: string;
-		let fileString: string = await readFileAsync(filename, {encoding: this.encoding}) as string;
+		let fileString: string = (await readFileAsync(filename, {encoding: this.encoding})).toString(this.encoding);
 		let fileContentLength: number = fileString.length;
 		let totalLoop: number = Math.ceil(fileContentLength / 1024);
 		let codeToken: string = '';


### PR DESCRIPTION
Use the `toString()` method of the `Buffer` to convert a file that is read to a `string`. Previous version was type casting, which worked before. Now the read file method returns a `Buffer`.