### PR TITLE
Update json5 to 2.2.3 and the version to 1.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to the "vscode-psl" extension will be documented in this
 file.
 
+## v1.13.4
+
+* Update the `json5` dependency to 2.2.3 and increment version numbers. Note
+  that this change is similar to 1.12.2, as the 1.13 version is a split from
+  1.12 for now.
+
 ## v1.13.3
 
 * Corrected highlight for storage modifier keywords in formal parameter rule.
@@ -18,6 +24,10 @@ file.
 ## v1.13.0
 
 * Language highlight enhancements.
+
+## v1.12.2
+
+* Update the `json5` dependency to 2.2.3 and increment version numbers.
 
 ## v1.12.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-psl",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-psl",
-      "version": "1.13.3",
+      "version": "1.13.4",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^10.1.0",
@@ -4104,9 +4104,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -8324,9 +8324,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jsonc-parser": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-psl",
   "displayName": "vscode-psl",
   "description": "Profile Scripting Language support",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "preview": true,
   "publisher": "ing-bank",
   "engines": {


### PR DESCRIPTION
Update the version of the json5 dependency to 2.2.3 and update the version of this project to 1.13.4. Note that this commit also added the changelog entry for 1.12.2. The current branch that is used for development of the 1.13 version of this app has massive changes compared to 1.12. That is why the changes are applied in two different branches.